### PR TITLE
Rename GitHub IDP

### DIFF
--- a/terraform/cloudflare-zerotrust/idp.tf
+++ b/terraform/cloudflare-zerotrust/idp.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_access_identity_provider" "github" {
   account_id = var.cloudflare_account_id
-  name       = "GitHub"
+  name       = "MorrisLAN GitHub"
   type       = "github"
   config {
     client_id     = var.github_client_id


### PR DESCRIPTION
Rename GitHub IDP in Cloudflare Zero Trust.